### PR TITLE
chore: separate group related to dependencies

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -104,7 +104,7 @@ commit_parsers = [
   { message = "^style", group = "<!-- 5 -->🎨 Styling" },
   { message = "^test", group = "<!-- 6 -->🧪 Testing" },
   { message = "^chore\\(release\\)", skip = true },
-  { message = "^chore\\(deps.*\\)", skip = true },
+  { message = "^chore\\(deps.*\\)", group = "<!-- 10 -->⬆️ Dependencies"},
   { message = "^chore\\(pr\\)", skip = true },
   { message = "^chore\\(pull\\)", skip = true },
   { message = "^chore\\(npm\\).*yarn\\.lock", skip = true },


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers will first have to approve the PR.
-->

## What? (description)

Separated dependency changes in git-cliff config.

## Why? (reasoning)

Release notes should have a Dependencies grouped in it's own header.