### PR TITLE
ci(release): squash prepare commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,12 +149,44 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
           VERSION: ${{ needs.version.outputs.version }}
 
-  release:
+  squash:
     if: startsWith(github.ref, 'refs/heads/release/')
     runs-on: gha-runner-scale-set
     needs:
       - version
       - changelog
+    permissions:
+      contents: write
+      packages: read
+      id-token: write
+    steps:
+      # Fetch repo
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # Squash release commits to avoid spam on main
+      - name: Squash release commits
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          git pull
+          git checkout $GITHUB_REF_NAME
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          set +e
+          git log $GITHUB_REF_NAME --oneline
+          git reset --soft HEAD~4
+          git diff --cached
+          git commit -m "chore(release): prepare v$VERSION"
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git $GITHUB_REF_NAME --force
+
+  release:
+    if: startsWith(github.ref, 'refs/heads/release/')
+    runs-on: gha-runner-scale-set
+    needs:
+      - version
+      - squash
     permissions:
       contents: write
       packages: read

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.23.4
 require (
 	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/gin-gonic/gin v1.10.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.20.1
 	gitlab.com/gitlab-org/api/client-go v0.130.1
 )

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/sagikazarmark/locafero v0.9.0 h1:GbgQGNtTrEmddYDSAH9QLRyfAHY12md+8YFTqyMTC9k=
 github.com/sagikazarmark/locafero v0.9.0/go.mod h1:UBUyz37V+EdMS3hDF3QWIiVr/2dPrx49OMO0Bn0hJqk=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=
@@ -116,7 +114,6 @@ golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
 golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
 golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
 golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
Release generates 4 commits (version bumps and changelog), needs squash.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers will first have to approve the PR.
-->

## What? (description)
Squash release prepare commits into one.

## Why? (reasoning)
Release process generates 4 commits - 3 with version bumps and one with changelog, which needs to be merge into main afterwards. This action results in 5 commits (including merge commit) added to main for each release, squashing those commits allow us to have clearer history that will result in one merge commit and one squashed commit for release.