### PR TITLE
fix: set resolve status after discussion creation

### DIFF
--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -160,11 +160,21 @@ func (c *Client) CreateUpdateMergeRequestDiscussion(projectID interface{}, mrID 
 		Body: &note,
 	}
 
+	// Create discussion
 	cD, _, err := c.client.Discussions.CreateMergeRequestDiscussion(projectID, mrID, cdOpts)
 	if err != nil {
 		return fmt.Errorf("failed to create merge request discussion: %w", err)
 	}
 	fmt.Printf("Created discussion, id: %s\n", cD.ID)
+
+	// Set resolve status
+	c.client.Discussions.ResolveMergeRequestDiscussion(projectID, mrID, cD.ID, &gitlab.ResolveMergeRequestDiscussionOptions{
+		Resolved: &passed,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set resolve status: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers will first have to approve the PR.
-->

## What? (description)

Update resolve status after discussion creation.

## Why? (reasoning)

When discussion was created and merge requests status checks were passing - bot didn't automatically update resolve status.
