### PR TITLE
fix(config): proper default config param

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,9 +102,9 @@ func Load() (*Config, error) {
 	// Set defaults
 	viper.SetDefault("server.port", 8080)
 	viper.SetDefault("server.host", "0.0.0.0")
+	viper.SetDefault("server.log_level", "INFO")
 	viper.SetDefault("gitlab.base_url", "https://gitlab.com")
 	viper.SetDefault("gitlab.insecure", false)
-	viper.SetDefault("log_level", "INFO")
 
 	if err := viper.ReadInConfig(); err != nil {
 		return nil, err

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -12,6 +12,7 @@ type Logger struct {
 }
 
 func New() *Logger {
+	// Defaults to INFO
 	return NewWithLevel("INFO")
 }
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers will first have to approve the PR.
-->

## What? (description)

Changed config param to `server.log_level`

## Why? (reasoning)
Previously used log_level, missing server object.
