### PR TITLE
ci(release): add missing changelog dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,7 @@ jobs:
     runs-on: gha-runner-scale-set
     needs:
       - version
+      - changelog
       - squash
     permissions:
       contents: write


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers will first have to approve the PR.
-->

## What? (description)

Added changelog `needs` dependency to pass release notes.

## Why? (reasoning)

Without passing release notes step output - release notes will be empty.
