### PR TITLE
fix: adjust jira regex

### DIFF
--- a/internal/conformity/helper/common/common.go
+++ b/internal/conformity/helper/common/common.go
@@ -9,7 +9,7 @@ import (
 // HeaderRegex is the regular expression used for Conventional Commits 1.0.0.
 var (
 	HeaderRegex = regexp.MustCompile(`^(\w*)(\(([^)]+)\))?(!)?:\s{1}(.*)($|\n{2})`)
-	JiraRegex   = regexp.MustCompile(`.*\s\[?([A-Z]+)-[1-9]\d*\]?.*`)
+	JiraRegex   = regexp.MustCompile(`.*\s\[?([A-Z0-9]+)-[1-9]\d*\]?.*`)
 )
 
 func ParseHeader(msg string) []string {


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers will first have to approve the PR.
-->

## What? (description)
Modified jira regex to match numbers in project names.
## Why? (reasoning)
Jira regex did not cover tasks from projects with number in the name, so for example PROJ20 didn't match, while it should.
