### PR TITLE
fix: Only start queue processor when queue is enabled

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -23,7 +23,6 @@ func main() {
 	log := logger.New()
 
 	log.Info("Starting bot", "version", Version)
-	log.Info("*** GitLab MR Conform with Asana Description Validation - Build 2025-12-05 ***")
 
 	// Load configuration
 	cfg, err := config.Load()


### PR DESCRIPTION
  Prevents Redis connection errors when queue.enabled is false by checking
  the config before starting the background processor.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers will first have to approve the PR.
-->

## What? (description)
Prevents Redis connection errors when queue.enabled is false by checking
  the config before starting the background processor.

## Why? (reasoning)
My logs were getting filled with error messages about redis not being accessible

## Acceptance
When queue is disabled, no error log messages should appear.

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you build (`make build`)
- [X] you ran tests (`make test`)

> See `make help` for a description of the available targets.
