### PR TITLE
feat: new approvals option exclude_creator_from_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ rules:
     enabled: false
     use_codeowners: true # Use .gitlab/CODEOWNERS file to require approvals from owners
     min_count: 1 # Checking just number of approvals, skipped if use_codeowners set to true
+    exclude_creator_from_count: false # If true, the MR creator cannot be counted as an approver
 
   squash:
     enabled: true

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -74,6 +74,7 @@ rules:
     enabled: true
     use_codeowners: false
     min_count: 1 # skipped if use_codeowners set to true
+    exclude_creator_from_count: false # if true, the MR creator cannot be counted as an approver
 
   squash:
     enabled: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,9 +90,10 @@ type CommitsConfig struct {
 }
 
 type ApprovalsConfig struct {
-	Enabled       bool `mapstructure:"enabled"`
-	MinCount      int  `mapstructure:"min_count"`
-	UseCodeowners bool `mapstructure:"use_codeowners"`
+	Enabled                 bool `mapstructure:"enabled"`
+	MinCount                int  `mapstructure:"min_count"`
+	UseCodeowners           bool `mapstructure:"use_codeowners"`
+	ExcludeCreatorFromCount bool `mapstructure:"exclude_creator_from_count"`
 }
 
 type SquashConfig struct {

--- a/internal/conformity/checker.go
+++ b/internal/conformity/checker.go
@@ -59,7 +59,7 @@ func (c *Checker) CheckMergeRequest(projectID interface{}, mrID int) (*CheckResu
 	rulesList := c.ruleBuilder.BuildRules(finalConfig)
 
 	// Get merge request and commits
-	mr, commits, approvals, err := c.fetchMergeRequestData(projectID, mrID)
+	mr, commits, approvals, err := c.fetchMergeRequestData(projectID, mrID, finalConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -97,14 +97,14 @@ func (c *Checker) CheckMergeRequest(projectID interface{}, mrID int) (*CheckResu
 }
 
 // fetchMergeRequestData retrieves merge request and commit data
-func (c *Checker) fetchMergeRequestData(projectID interface{}, mrID int) (*gitlabapi.MergeRequest, []*gitlabapi.Commit, *common.Approvals, error) {
+func (c *Checker) fetchMergeRequestData(projectID interface{}, mrID int, finalConfig config.RulesConfig) (*gitlabapi.MergeRequest, []*gitlabapi.Commit, *common.Approvals, error) {
 	// Get merge request details
 	mr, err := c.gitlabClient.GetMergeRequest(projectID, mrID)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get merge request: %w", err)
 	}
 	// Get mr approvers
-	approvals, err := c.gitlabClient.ListMergeRequestApprovals(projectID, mrID)
+	approvals, err := c.gitlabClient.ListMergeRequestApprovals(projectID, mrID, mr.Author.ID, finalConfig.Approvals.ExcludeCreatorFromCount)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get merge request: %w", err)
 	}


### PR DESCRIPTION
# Pull Request

## What? (description)

This PR adds a new configuration option `exclude_creator_from_count` to the approvals rule. When enabled, the merge request creator's approval will not be counted towards the `min_count` requirement, preventing self-approval scenarios.

**Changes:**
- Added `exclude_creator_from_count` field to `ApprovalsConfig` in `internal/config/config.go`
- Modified `ListMergeRequestApprovals` in `internal/gitlab/client.go` to accept creator ID and conditionally exclude them from approval count
- Updated `fetchMergeRequestData` in `internal/conformity/checker.go` to pass configuration to approval logic
- Added configuration option to `configs/config.yaml` example with documentation
- Updated `README.md` to document the new feature
- Fixed pre-existing error handling bugs in `client.go`

## Why? (reasoning)

Many teams want to enforce that merge requests require approval from someone other than the author. While GitLab has native settings for this, having it in the conformity checker provides:

1. **Consistency**: Enforcement happens at the same layer as other conformity checks
2. **Flexibility**: Can be configured per-project via `.mr-conform.yaml`
3. **Clear feedback**: Violations are reported in the same structured format as other rule failures
4. **Bypass protection**: Works even if GitLab project settings allow self-approval

This is particularly useful for teams that want to ensure code review quality without requiring admin-level GitLab configuration changes.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you build (`make build`)
- [ ] you ran tests (`make test`)

> See `make help` for a description of the available targets.

**Testing:**
- Manual testing performed with local GitLab instance via Docker Compose
- Verified approval counting with `exclude_creator_from_count: true` and `false`
- Confirmed backward compatibility (defaults to `false`)