### PR TITLE
chore(deps): golang bump to 1.25.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for Go bot application
 # Supports both AMD64 and ARM64 architectures
 
-FROM --platform=$BUILDPLATFORM golang:1.24.4-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.9-alpine AS build
 
 # Set working directory
 WORKDIR /app
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     -o bot ./cmd/bot
 
 # Final stage - minimal distroless image
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static-debian12:nonroot
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static-debian13:nonroot
 
 # Copy binary and configs from build stage
 COPY --from=build --chown=nonroot:nonroot /app/bot /

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gitlab-mr-conformity-bot
 
-go 1.24.4
+go 1.25.9
 
 require (
 	github.com/bmatcuk/doublestar v1.3.4


### PR DESCRIPTION
# Pull Request

## What? (description)

Bumped golang to 1.25.9
Bumped distroless debian to 13

## Why? (reasoning)

CVE
